### PR TITLE
fix: harden MSG URL extraction

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.8
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2019-2025 Splunk Inc.
+   Copyright (c) 2019-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR App: MSG File Parser
-Copyright (c) 2019-2025 Splunk Inc.
+Copyright (c) 2019-2026 Splunk Inc.
 Third Party Software Attributions:
 
 @@@@============================================================================
@@ -35,7 +35,7 @@ SOFTWARE.
 
 Library: compressed-rtf - 1.0.7
 Homepage: https://github.com/delimitry/compressed_rtf
-License: UNKNOWN
+License: MIT
 License Text:
 
 The MIT License (MIT)
@@ -89,4 +89,3 @@ GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWE
 AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
-

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2019-2025 Splunk Inc.
+# Copyright (c) 2019-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/msgfileparser.json
+++ b/msgfileparser.json
@@ -9,7 +9,7 @@
     "product_name": "MSG File Parser",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2019-2025 Splunk Inc.",
+    "license": "Copyright (c) 2019-2026 Splunk Inc.",
     "app_version": "2.2.9",
     "utctime_updated": "2025-09-23T19:10:39.661126Z",
     "package_name": "phantom_msgfileparser",

--- a/msgfileparser_connector.py
+++ b/msgfileparser_connector.py
@@ -284,6 +284,9 @@ class MsgFileParserConnector(BaseConnector):
         scheme, remainder = url.split("://", 1)
         return f"{scheme.lower()}://{remainder}"
 
+    def _remove_whatwg_whitespace(self, value):
+        return value.translate({ord("\t"): None, ord("\n"): None, ord("\r"): None})
+
     def _is_ipv6(self, input_ip):
         try:
             socket.inet_pton(socket.AF_INET6, input_ip)
@@ -356,20 +359,21 @@ class MsgFileParserConnector(BaseConnector):
         uris = []
         # get all href tags
         links = soup.find_all(href=True)
+        href_values = [self._remove_whatwg_whitespace(x["href"]) for x in links]
         if links:
-            uris = [x["href"] for x in links if not x["href"].startswith("mailto:")]
-            uri_text = [self._clean_url(x.get_text()) for x in links]
+            uris = [href for href in href_values if not href.lower().startswith("mailto:")]
+            uri_text = [self._clean_url(self._remove_whatwg_whitespace(x.get_text())) for x in links]
             if uri_text:
                 uri_text = [x for x in uri_text if x.startswith("http")]
                 if uri_text:
                     uris.extend(uri_text)
         else:
             # parse it as a text file
-            uris = re.findall(uri_regexc, file_data)
+            uris = re.findall(uri_regexc, self._remove_whatwg_whitespace(file_data))
             if uris:
                 uris = [self._clean_url(x) for x in uris]
 
-        uris = [self._normalize_url_scheme(self._clean_url(uri)) for uri in uris]
+        uris = [self._normalize_url_scheme(self._clean_url(self._remove_whatwg_whitespace(uri))) for uri in uris]
         urls |= set(uris)
 
         # exctract domains
@@ -380,7 +384,7 @@ class MsgFileParserConnector(BaseConnector):
 
         # work on any mailto urls if present
         if links:
-            emails = [x["href"] for x in links if x["href"].startswith("mailto")]
+            emails = [href for href in href_values if href.lower().startswith("mailto:")]
         else:
             # parse as text
             emails = []

--- a/msgfileparser_connector.py
+++ b/msgfileparser_connector.py
@@ -1,6 +1,6 @@
 # File: msgfileparser_connector.py
 #
-# Copyright (c) 2019-2025 Splunk Inc.
+# Copyright (c) 2019-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ class MsgFileParserConnector(BaseConnector):
 
     def _add_vault_hashes_to_dictionary(self, cef_artifact, vault_id, action_result):
         try:
-            success, message, vault_info = ph_rules.vault_info(vault_id=vault_id)
+            _success, _message, vault_info = ph_rules.vault_info(vault_id=vault_id)
             vault_info = next(iter(vault_info))
         except Exception as e:
             error_message = self._get_error_message_from_exception(e)
@@ -488,7 +488,7 @@ class MsgFileParserConnector(BaseConnector):
         # get the .msg file from the vault
         vault_id = param["vault_id"]
         try:
-            success, message, vault_info = ph_rules.vault_info(vault_id=vault_id)
+            _success, message, vault_info = ph_rules.vault_info(vault_id=vault_id)
             vault_info = next(iter(vault_info))
             vault_path = vault_info["path"]
         except Exception as e:

--- a/msgfileparser_connector.py
+++ b/msgfileparser_connector.py
@@ -357,23 +357,26 @@ class MsgFileParserConnector(BaseConnector):
             return action_result.set_status(phantom.APP_ERROR, err)
 
         uris = []
-        # get all href tags
         links = soup.find_all(href=True)
         href_values = [self._remove_whatwg_whitespace(x["href"]) for x in links]
-        if links:
-            uris = [href for href in href_values if not href.lower().startswith("mailto:")]
-            uri_text = [self._clean_url(self._remove_whatwg_whitespace(x.get_text())) for x in links]
-            if uri_text:
-                uri_text = [x for x in uri_text if x.startswith("http")]
-                if uri_text:
-                    uris.extend(uri_text)
-        else:
-            # parse it as a text file
-            uris = re.findall(uri_regexc, self._remove_whatwg_whitespace(file_data))
-            if uris:
-                uris = [self._clean_url(x) for x in uris]
+        uris.extend(href for href in href_values if not href.lower().startswith("mailto:"))
+        uris.extend(self._remove_whatwg_whitespace(link.get_text()) for link in links)
+
+        for attribute in ("src", "action"):
+            uris.extend(self._remove_whatwg_whitespace(element[attribute]) for element in soup.find_all(**{attribute: True}))
+
+        for meta in soup.find_all("meta"):
+            if str(meta.get("http-equiv", "")).lower() != "refresh":
+                continue
+            content = self._remove_whatwg_whitespace(str(meta.get("content", "")))
+            match = re.search(r"(?:^|;)\s*url\s*=\s*(.+)\s*$", content, re.IGNORECASE)
+            if match:
+                uris.append(match.group(1).strip(" '\""))
+
+        uris.extend(re.findall(uri_regexc, self._remove_whatwg_whitespace(file_data)))
 
         uris = [self._normalize_url_scheme(self._clean_url(self._remove_whatwg_whitespace(uri))) for uri in uris]
+        uris = [uri for uri in uris if uri.lower().startswith(("http://", "https://"))]
         urls |= set(uris)
 
         # exctract domains
@@ -382,14 +385,10 @@ class MsgFileParserConnector(BaseConnector):
             if domain and not self._is_ip(domain):
                 domains.add(domain)
 
-        # work on any mailto urls if present
-        if links:
-            emails = [href for href in href_values if href.lower().startswith("mailto:")]
-        else:
-            # parse as text
-            emails = []
-            emails.extend(re.findall(email_regexc, file_data))
-            emails.extend(re.findall(email_regexc2, file_data))
+        # Work on mailto URLs and bare-text addresses independently.
+        emails = [href for href in href_values if href.lower().startswith("mailto:")]
+        emails.extend(re.findall(email_regexc, file_data))
+        emails.extend(re.findall(email_regexc2, file_data))
 
         for curr_email in emails:
             domain = curr_email[curr_email.find("@") + 1 :]

--- a/msgfileparser_connector.py
+++ b/msgfileparser_connector.py
@@ -278,6 +278,12 @@ class MsgFileParserConnector(BaseConnector):
 
         return url
 
+    def _normalize_url_scheme(self, url):
+        if "://" not in url:
+            return url
+        scheme, remainder = url.split("://", 1)
+        return f"{scheme.lower()}://{remainder}"
+
     def _is_ipv6(self, input_ip):
         try:
             socket.inet_pton(socket.AF_INET6, input_ip)
@@ -338,7 +344,7 @@ class MsgFileParserConnector(BaseConnector):
     def _extract_urls_domains(self, action_result, file_data, urls, domains):
         email_regexc = re.compile(EMAIL_REGEX, re.IGNORECASE)
         email_regexc2 = re.compile(EMAIL_REGEX2, re.IGNORECASE)
-        uri_regexc = re.compile(URI_REGEX)
+        uri_regexc = re.compile(URI_REGEX, re.IGNORECASE)
 
         try:
             soup = BeautifulSoup(file_data, "html.parser")
@@ -363,6 +369,7 @@ class MsgFileParserConnector(BaseConnector):
             if uris:
                 uris = [self._clean_url(x) for x in uris]
 
+        uris = [self._normalize_url_scheme(self._clean_url(uri)) for uri in uris]
         urls |= set(uris)
 
         # exctract domains

--- a/msgfileparser_consts.py
+++ b/msgfileparser_consts.py
@@ -36,6 +36,6 @@ MSGFILEPARSER_PARSER_DECODE_ERR = "Failed to parse message. Error: {}"
 MSGFILEPARSER_EXTRACT_EMAIL_ACTION = "extract_email"
 
 # Regex statements used for extraction
-URI_REGEX = r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
+URI_REGEX = r"https?://[^\s<>'\"\\]+"
 EMAIL_REGEX = r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b"
 EMAIL_REGEX2 = r'".*"@[A-Z0-9.-]+\.[A-Z]{2,}\b'

--- a/msgfileparser_consts.py
+++ b/msgfileparser_consts.py
@@ -1,6 +1,6 @@
 # File: msgfileparser_consts.py
 #
-# Copyright (c) 2019-2025 Splunk Inc.
+# Copyright (c) 2019-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Extract uppercase-scheme and internationalized-domain URLs.
+* Normalize WHATWG ASCII whitespace before recording URL artifacts.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Extract uppercase-scheme and internationalized-domain URLs.
 * Normalize WHATWG ASCII whitespace before recording URL artifacts.
+* Extract bare-text, source, form-action, and refresh URLs alongside links.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Extract uppercase-scheme and internationalized-domain URLs.


### PR DESCRIPTION
## Summary

- extract uppercase-scheme and internationalized-domain URLs
- normalize WHATWG ASCII whitespace before classifying URL and mailto values
- combine href, visible text, src, form action, meta refresh, and bare-text scans
- keep the three independent fixes separated in commits and release notes

## Tracking

- Parent: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)
- PAPP: [PAPP-38256](https://splunk.atlassian.net/browse/PAPP-38256)
- Findings: [PSAAS-31836](https://splunk.atlassian.net/browse/PSAAS-31836), [PSAAS-31870](https://splunk.atlassian.net/browse/PSAAS-31870), [PSAAS-32439](https://splunk.atlassian.net/browse/PSAAS-32439)
- App classification: Certified Apps (publisher: Splunk)

## Quality gate

- `pre-commit run --all-files`
- `python3 -m compileall -q -x '.*/\.venv/.*' .`

Created by Codex with AI assistance.

## Tracking

- PAPP: PAPP-38256
- PSAAS: PSAAS-31836, PSAAS-31870, PSAAS-32439
- Written by Codex.